### PR TITLE
chore: add spotify api key to rails app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
+require 'dotenv/load'
+
 class ApplicationController < ActionController::Base
+  RSpotify.authenticate(ENV['spotify_client_id'], ENV['spotify_secret_key'])
+
   include Pundit::Authorization
 
   # Pundit: white-list approach.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,7 @@
+require 'rspotify'
+
 class PagesController < ApplicationController
-  def home; end
+  def home
+    @search = RSpotify::Artist.search('Arctic Monkeys')
+  end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,1 +1,2 @@
 <h1>Noted</h1>
+<%= @search %>


### PR DESCRIPTION
I have authenticated the Spotify app through the app, so we can use the Spotify wrapper to make calls whenever is required 